### PR TITLE
Server unit test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,17 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
+    "chai": "^4.0.2",
     "express": "^4.15.0",
     "jest-cli": "^20.0.4",
     "jquery": "^3.1.1",
+    "mocha": "^3.4.2",
     "pg-bluebird": "^1.0.8",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
+    "supertest": "^3.0.0",
     "underscore": "^1.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server/index.js",
     "react-dev": "webpack -d --watch",
     "server-dev": "nodemon server/index.js",
-    "test": "jest"
+    "test": "jest",
+    "mocha": "mocha server/tests"
   },
   "author": "Scott Yoon, Corey Chau, Joe Lei, Matthew Reyes",
   "license": "ISC",
@@ -19,8 +20,10 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
     "babel-register": "^6.7.2",
+    "chai-http": "^3.0.0",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",
     "jest": "^20.0.4",
+    "mocha": "^3.4.2",
     "regenerator-runtime": "^0.10.5",
     "webpack": "^2.2.1"
   },

--- a/server/tests/test-server.js
+++ b/server/tests/test-server.js
@@ -1,0 +1,15 @@
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+// var server = require('../server/index.js');
+var should = chai.should();
+
+chai.use(chaiHttp);
+
+
+describe('Blobs', function() {
+  it('should list ALL blobs on /blobs GET');
+  it('should list a SINGLE blob on /blob/<id> GET');
+  it('should add a SINGLE blob on /blobs POST');
+  it('should update a SINGLE blob on /blob/<id> PUT');
+  it('should delete a SINGLE blob on /blob/<id> DELETE');
+});

--- a/server/tests/test-server.js
+++ b/server/tests/test-server.js
@@ -1,7 +1,7 @@
-var chai = require('chai');
-var chaiHttp = require('chai-http');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
 // var server = require('../server/index.js');
-var should = chai.should();
+const should = chai.should();
 
 chai.use(chaiHttp);
 


### PR DESCRIPTION
Added dependencies  for mocha, chai, and supertest. 

Added some sample tests.

Use in the terminal 'npm run mocha' to test using mocha.